### PR TITLE
Prevent variable names from being converted to links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ In order for you to make a contribution directly please follow the next steps:
 - if you wish to test your changes locally you can follow the [DOCFX Installation guideline](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html) and [build the entire solution locally](https://dotnet.github.io/docfx/tutorial/walkthrough/walkthrough_create_a_docfx_project.html)
 - Our documentation automatically fills in the product name and other details so you don't have to make the changes manually if we decide to update the product name. Use the '<var:VariableName>' construct to tell our documentation engine to fill in the info for you. Here are the constructs available at this point:
 
-      <var:ProductName> - The product name, for example Trados Cloud
+      Var:ProductName - The product name, for example Trados Cloud
       

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
-# Access the <Var:ProductName> APIs
-<Var:ProductName> is the platform on which RWS host a number of products. You're in the right place if you're looking for API documentation for any of the following:
+# Access the Var:ProductName APIs
+Var:ProductName is the platform on which RWS host a number of products. You're in the right place if you're looking for API documentation for any of the following:
 - Trados Enterprise
 - Trados Accelerate
 - Trados Team
@@ -7,14 +7,14 @@
 - Trados Studio (cloud capabilities)
 - Trados Go
 
-## Integrating with <Var:ProductName> products
+## Integrating with Var:ProductName products
 To create an integration with any of the products listed above, you'll need to use the Public API. You can find the documentation for the API [here](https://languagecloud.sdl.com/lc/api-docs). Note that the API is updated regularly so make sure that you check out the [What's new](https://languagecloud.sdl.com/lc/api-docs/whats-new) section to find out information on recently added features. To enable RWS to extend and improve the API, and to support the latest features in the products, sometimes it's necessary to remove or change functionality. For that, you'll need to check the [What's deprecated](https://languagecloud.sdl.com/lc/api-docs/whats-deprecated) page where RWS will post advance notice of any API endpoints that will be removed or change in the future. Don't worry though because RWS will try and give six months notice of any breaking changes.
 
-## Extending <Var:ProductName> products
-<Var:ProductName> products can be extended in a number of ways. For example, you may want to create an add-on to support a machine translation engine or you may want to create a custom workflow task. RWS provides an extensibility framework for the <Var:ProductName> suite of products. To get more information on what's required and how you can do this, visit the [<Var:ProductName> extensibility documentation](https://languagecloud.sdl.com/lc/extensibility-docs) pages. 
+## Extending Var:ProductName products
+Var:ProductName products can be extended in a number of ways. For example, you may want to create an add-on to support a machine translation engine or you may want to create a custom workflow task. RWS provides an extensibility framework for the Var:ProductName suite of products. To get more information on what's required and how you can do this, visit the [Var:ProductName extensibility documentation](https://languagecloud.sdl.com/lc/extensibility-docs) pages. 
 
 ## Interacting with files
-Translatable content in <Var:ProductName> is held in a format called **Bilingual Content Model**, or **BCM** for short. You can find **BCM** reference documentation and samples on this site. Click [here](articles/bcm/BCM.NET_client_API.md) to find out more.
+Translatable content in Var:ProductName is held in a format called **Bilingual Content Model**, or **BCM** for short. You can find **BCM** reference documentation and samples on this site. Click [here](articles/bcm/BCM.NET_client_API.md) to find out more.
 
 ## Reporting API issues ##
 If you want to report an issue with the API, you can find information on how to do this here - [How to report an issue](https://languagecloud.sdl.com/lc/api-docs/how-to-report-an-issue)


### PR DESCRIPTION
Change <Var:ProductName> to Var:ProductName